### PR TITLE
Chore/rename IS -> Is

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,15 +47,15 @@ func (t *remover) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err er
 
 	writeBufLen = len(buf)
 	switch {
-	case ISUTF32BigEndianBOM(buf):
+	case IsUTF32BigEndianBOM(buf):
 		buf = buf[BOMSize4Byte:]
-	case ISUTF32LittleEndianBOM(buf):
+	case IsUTF32LittleEndianBOM(buf):
 		buf = buf[BOMSize4Byte:]
-	case ISUTF8BOM(buf):
+	case IsUTF8BOM(buf):
 		buf = buf[BOMSize3Byte:]
-	case ISUTF16BigEndianBOM(buf):
+	case IsUTF16BigEndianBOM(buf):
 		buf = buf[BOMSize2Byte:]
-	case ISUTF16LittleEndianBOM(buf):
+	case IsUTF16LittleEndianBOM(buf):
 		buf = buf[BOMSize2Byte:]
 	}
 
@@ -74,22 +74,22 @@ func (t *remover) Reset() {
 	t.counter = 0
 }
 
-func ISUTF32BigEndianBOM(buf []byte) bool {
+func IsUTF32BigEndianBOM(buf []byte) bool {
 	return len(buf) >= BOMSize4Byte && buf[0] == 0x00 && buf[1] == 0x00 && buf[2] == 0xFE && buf[3] == 0xFF
 }
 
-func ISUTF32LittleEndianBOM(buf []byte) bool {
+func IsUTF32LittleEndianBOM(buf []byte) bool {
 	return len(buf) >= BOMSize4Byte && buf[0] == 0xFF && buf[1] == 0xFE && buf[2] == 0x00 && buf[3] == 0x00
 }
 
-func ISUTF8BOM(buf []byte) bool {
+func IsUTF8BOM(buf []byte) bool {
 	return len(buf) >= BOMSize3Byte && buf[0] == 0xEF && buf[1] == 0xBB && buf[2] == 0xBF
 }
 
-func ISUTF16BigEndianBOM(buf []byte) bool {
+func IsUTF16BigEndianBOM(buf []byte) bool {
 	return len(buf) >= BOMSize2Byte && buf[0] == 0xFE && buf[1] == 0xFF
 }
 
-func ISUTF16LittleEndianBOM(buf []byte) bool {
+func IsUTF16LittleEndianBOM(buf []byte) bool {
 	return len(buf) >= BOMSize2Byte && buf[0] == 0xFF && buf[1] == 0xFE
 }

--- a/main_test.go
+++ b/main_test.go
@@ -275,31 +275,31 @@ func FuzzTransformer(f *testing.F) {
 		f.Add(b)
 	}
 	f.Fuzz(func(t *testing.T, p []byte) {
-		if (utfbomremover.ISUTF32BigEndianBOM(p) && utfbomremover.ISUTF32BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32BigEndianBOM(p) && utfbomremover.ISUTF32LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32BigEndianBOM(p) && utfbomremover.ISUTF8BOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32BigEndianBOM(p) && utfbomremover.ISUTF16BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32BigEndianBOM(p) && utfbomremover.ISUTF16LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32LittleEndianBOM(p) && utfbomremover.ISUTF32BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32LittleEndianBOM(p) && utfbomremover.ISUTF32LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32LittleEndianBOM(p) && utfbomremover.ISUTF8BOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32LittleEndianBOM(p) && utfbomremover.ISUTF16BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF32LittleEndianBOM(p) && utfbomremover.ISUTF16LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
-			(utfbomremover.ISUTF8BOM(p) && utfbomremover.ISUTF32BigEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
-			(utfbomremover.ISUTF8BOM(p) && utfbomremover.ISUTF32LittleEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
-			(utfbomremover.ISUTF8BOM(p) && utfbomremover.ISUTF8BOM(p[utfbomremover.BOMSize3Byte:])) ||
-			(utfbomremover.ISUTF8BOM(p) && utfbomremover.ISUTF16BigEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
-			(utfbomremover.ISUTF8BOM(p) && utfbomremover.ISUTF16LittleEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
-			(utfbomremover.ISUTF16BigEndianBOM(p) && utfbomremover.ISUTF32BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16BigEndianBOM(p) && utfbomremover.ISUTF32LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16BigEndianBOM(p) && utfbomremover.ISUTF8BOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16BigEndianBOM(p) && utfbomremover.ISUTF16BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16BigEndianBOM(p) && utfbomremover.ISUTF16LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16LittleEndianBOM(p) && utfbomremover.ISUTF32BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16LittleEndianBOM(p) && utfbomremover.ISUTF32LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16LittleEndianBOM(p) && utfbomremover.ISUTF8BOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16LittleEndianBOM(p) && utfbomremover.ISUTF16BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
-			(utfbomremover.ISUTF16LittleEndianBOM(p) && utfbomremover.ISUTF16LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) {
+		if (utfbomremover.IsUTF32BigEndianBOM(p) && utfbomremover.IsUTF32BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32BigEndianBOM(p) && utfbomremover.IsUTF32LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32BigEndianBOM(p) && utfbomremover.IsUTF8BOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32BigEndianBOM(p) && utfbomremover.IsUTF16BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32BigEndianBOM(p) && utfbomremover.IsUTF16LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32LittleEndianBOM(p) && utfbomremover.IsUTF32BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32LittleEndianBOM(p) && utfbomremover.IsUTF32LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32LittleEndianBOM(p) && utfbomremover.IsUTF8BOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32LittleEndianBOM(p) && utfbomremover.IsUTF16BigEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF32LittleEndianBOM(p) && utfbomremover.IsUTF16LittleEndianBOM(p[utfbomremover.BOMSize4Byte:])) ||
+			(utfbomremover.IsUTF8BOM(p) && utfbomremover.IsUTF32BigEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
+			(utfbomremover.IsUTF8BOM(p) && utfbomremover.IsUTF32LittleEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
+			(utfbomremover.IsUTF8BOM(p) && utfbomremover.IsUTF8BOM(p[utfbomremover.BOMSize3Byte:])) ||
+			(utfbomremover.IsUTF8BOM(p) && utfbomremover.IsUTF16BigEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
+			(utfbomremover.IsUTF8BOM(p) && utfbomremover.IsUTF16LittleEndianBOM(p[utfbomremover.BOMSize3Byte:])) ||
+			(utfbomremover.IsUTF16BigEndianBOM(p) && utfbomremover.IsUTF32BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16BigEndianBOM(p) && utfbomremover.IsUTF32LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16BigEndianBOM(p) && utfbomremover.IsUTF8BOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16BigEndianBOM(p) && utfbomremover.IsUTF16BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16BigEndianBOM(p) && utfbomremover.IsUTF16LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16LittleEndianBOM(p) && utfbomremover.IsUTF32BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16LittleEndianBOM(p) && utfbomremover.IsUTF32LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16LittleEndianBOM(p) && utfbomremover.IsUTF8BOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16LittleEndianBOM(p) && utfbomremover.IsUTF16BigEndianBOM(p[utfbomremover.BOMSize2Byte:])) ||
+			(utfbomremover.IsUTF16LittleEndianBOM(p) && utfbomremover.IsUTF16LittleEndianBOM(p[utfbomremover.BOMSize2Byte:])) {
 			t.Skip()
 		}
 		tr := utfbomremover.NewTransformer()
@@ -308,19 +308,19 @@ func FuzzTransformer(f *testing.F) {
 			if err != nil {
 				t.Fatal("unexpected error:", err)
 			}
-			if utfbomremover.ISUTF32BigEndianBOM(r) {
+			if utfbomremover.IsUTF32BigEndianBOM(r) {
 				t.Fatalf("utf-32 be bom [%X]", r)
 			}
-			if utfbomremover.ISUTF32LittleEndianBOM(r) {
+			if utfbomremover.IsUTF32LittleEndianBOM(r) {
 				t.Fatalf("utf-32 le bom [%X]", r)
 			}
-			if utfbomremover.ISUTF8BOM(r) {
+			if utfbomremover.IsUTF8BOM(r) {
 				t.Fatalf("utf-8 bom [%X]", r)
 			}
-			if utfbomremover.ISUTF16BigEndianBOM(r) {
+			if utfbomremover.IsUTF16BigEndianBOM(r) {
 				t.Fatalf("utf-16 be bom [%X]", r)
 			}
-			if utfbomremover.ISUTF16LittleEndianBOM(r) {
+			if utfbomremover.IsUTF16LittleEndianBOM(r) {
 				t.Fatalf("utf-16 le bom [%X]", r)
 			}
 			p = p[n:]


### PR DESCRIPTION
作者が伊豆に行き過ぎたせいで関数名のIsが大文字化していた
IZUと書かなかっただけマシである